### PR TITLE
add latency_timer value to adjust dxl comms errors

### DIFF
--- a/python/stretch_tool_share/dry_erase_holder_v1/params.py
+++ b/python/stretch_tool_share/dry_erase_holder_v1/params.py
@@ -5,6 +5,7 @@ params = {
         'use_group_sync_read': 1,
         'baud': 57600,
         'retry_on_comm_failure': 1,
+        'dxl_latency_timer': 64,
         'verbose':0,
         'stow': {'wrist_yaw': 3.4},
         'devices': {

--- a/python/stretch_tool_share/stretch_dex_wrist/params.py
+++ b/python/stretch_tool_share/stretch_dex_wrist/params.py
@@ -11,6 +11,7 @@ params = {
         'use_group_sync_read': 1,
         'retry_on_comm_failure': 1,
         'baud':115200,
+        'dxl_latency_timer': 64,
         'verbose':0,
         'stow': {
             'arm': 0.0,

--- a/python/stretch_tool_share/stretch_dex_wrist_beta/params.py
+++ b/python/stretch_tool_share/stretch_dex_wrist_beta/params.py
@@ -11,6 +11,7 @@ params = {
         'use_group_sync_read': 1,
         'retry_on_comm_failure': 1,
         'baud':115200,
+        'dxl_latency_timer': 64,
         'verbose':0,
         'stow': {
             'arm': 0.0,

--- a/python/stretch_tool_share/usbcam_wrist_v1/params.py
+++ b/python/stretch_tool_share/usbcam_wrist_v1/params.py
@@ -4,6 +4,7 @@ params = {
         'py_module_name': 'stretch_tool_share.usbcam_wrist_v1.tool',
         'use_group_sync_read': 1,
         'baud': 57600,
+        'dxl_latency_timer': 64,
         'retry_on_comm_failure': 1,
         'verbose':0,
         'stow': {'wrist_yaw': 3.4},


### PR DESCRIPTION
This adds a parameter to set the latency_timer for the dxl communications. Requires compatible Stretch Body update. 