### PR TITLE
Feature/runstop select

### DIFF
--- a/python/stretch_tool_share/stretch_dex_wrist/params.py
+++ b/python/stretch_tool_share/stretch_dex_wrist/params.py
@@ -65,6 +65,7 @@ params = {
     },
     "wrist_pitch": {
         'flip_encoder_polarity': 1,
+        'enable_runstop': 1,
         'gr': 1.0,
         'id': 15,
         'max_voltage_limit': 15,
@@ -95,6 +96,7 @@ params = {
     },
     "wrist_roll": {
         'flip_encoder_polarity': 0,
+        'enable_runstop': 1,
         'gr': 1.0,
         'id': 16,
         'max_voltage_limit': 16,

--- a/python/stretch_tool_share/stretch_dex_wrist_beta/params.py
+++ b/python/stretch_tool_share/stretch_dex_wrist_beta/params.py
@@ -65,6 +65,7 @@ params = {
     },
     "wrist_pitch": {
         'flip_encoder_polarity': 1,
+        'enable_runstop': 1,
         'gr': 1.0,
         'id': 15,
         'max_voltage_limit': 15,
@@ -95,6 +96,7 @@ params = {
     },
     "wrist_roll": {
         'flip_encoder_polarity': 0,
+        'enable_runstop': 1,
         'gr': 1.0,
         'id': 16,
         'max_voltage_limit': 16,


### PR DESCRIPTION
Added runstop_enable to Dynamixel params. This is required to be compatible with Stretch Body  v0.1.x where each servo can be individually tied to the runstop or not.