### PR TITLE
make stretch_tool_share to catkin package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(stretch_tool_share)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+include_directories(
+# include
+# ${catkin_INCLUDE_DIRS}
+)

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>stretch_tool_share</name>
+  <version>0.0.0</version>
+  <description>The stretch_tool_share package</description>
+
+  <maintainer email="todo@todo.todo">TODO</maintainer>
+
+  <license>TODO</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>stretch_ros</exec_depend>
+
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+  </export>
+</package>

--- a/tool_share/stretch_dex_wrist/stretch_description/urdf/stretch_description.xacro
+++ b/tool_share/stretch_dex_wrist/stretch_description/urdf/stretch_description.xacro
@@ -1,16 +1,15 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_description">
 
-  <xacro:include filename="stretch_dex_wrist.xacro" />
-  <!--<xacro:include filename="stretch_gripper.xacro" /> -->
-  <!--<xacro:include filename="stretch_gripper_with_puller.xacro" />-->
-  <!--<xacro:include filename="stretch_dry_erase_marker.xacro" />-->
-    
-  <xacro:include filename="stretch_main.xacro" />
-  <xacro:include filename="stretch_aruco.xacro" />
-  <xacro:include filename="stretch_d435i.xacro" />
-  <xacro:include filename="stretch_laser_range_finder.xacro" />
-  <xacro:include filename="stretch_respeaker.xacro" />
+    <xacro:include filename="$(find stretch_tool_share)/tool_share/stretch_dex_wrist/stretch_description/urdf/stretch_dex_wrist.xacro" />
+  <!--<xacro:include filena$(find stretch_description)/urdfme="stretch_gripper.xacro" /> -->
+  <!--<xacro:include filena$(find stretch_description)/urdfme="stretch_gripper_with_puller.xacro" />-->
+  <!--<xacro:include filena$(find stretch_description)/urdfme="stretch_dry_erase_marker.xacro" />-->
+  <xacro:include filename="$(find stretch_description)/urdf/stretch_main.xacro" />
+  <xacro:include filename="$(find stretch_description)/urdf/stretch_aruco.xacro" />
+  <xacro:include filename="$(find stretch_description)/urdf/stretch_d435i.xacro" />
+  <xacro:include filename="$(find stretch_description)/urdf/stretch_laser_range_finder.xacro" />
+  <xacro:include filename="$(find stretch_description)/urdf/stretch_respeaker.xacro" />
 
 </robot>
 

--- a/tool_share/stretch_dex_wrist/stretch_description/urdf/stretch_description.xacro
+++ b/tool_share/stretch_dex_wrist/stretch_description/urdf/stretch_description.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch_description">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="stretch">
 
     <xacro:include filename="$(find stretch_tool_share)/tool_share/stretch_dex_wrist/stretch_description/urdf/stretch_dex_wrist.xacro" />
   <!--<xacro:include filena$(find stretch_description)/urdfme="stretch_gripper.xacro" /> -->

--- a/tool_share/stretch_dex_wrist/stretch_description/urdf/stretch_dex_wrist.xacro
+++ b/tool_share/stretch_dex_wrist/stretch_description/urdf/stretch_dex_wrist.xacro
@@ -25,7 +25,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://stretch_description/meshes/link_wrist_yaw_bottom.STL" />
+          filename="package://stretch_tool_share/tool_share/stretch_dex_wrist/stretch_description/meshes/link_wrist_yaw_bottom.STL" />
       </geometry>
       <material
         name="">
@@ -39,7 +39,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://stretch_description/meshes/link_wrist_yaw_bottom.STL" />
+          filename="package://stretch_tool_share/tool_share/stretch_dex_wrist/stretch_description/meshes/link_wrist_yaw_bottom.STL" />
       </geometry>
     </collision>
   </link>
@@ -78,7 +78,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://stretch_description/meshes/link_wrist_pitch.STL" />
+          filename="package://stretch_tool_share/tool_share/stretch_dex_wrist/stretch_description/meshes/link_wrist_pitch.STL" />
       </geometry>
       <material
         name="">
@@ -92,7 +92,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://stretch_description/meshes/link_wrist_pitch.STL" />
+          filename="package://stretch_tool_share/tool_share/stretch_dex_wrist/stretch_description/meshes/link_wrist_pitch.STL" />
       </geometry>
     </collision>
   </link>
@@ -132,7 +132,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://stretch_description/meshes/link_wrist_roll.STL" />
+          filename="package://stretch_tool_share/tool_share/stretch_dex_wrist/stretch_description/meshes/link_wrist_roll.STL" />
       </geometry>
       <material
         name="">
@@ -146,7 +146,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://stretch_description/meshes/link_wrist_roll.STL" />
+          filename="package://stretch_tool_share/tool_share/stretch_dex_wrist/stretch_description/meshes/link_wrist_roll.STL" />
       </geometry>
     </collision>
   </link>
@@ -186,7 +186,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://stretch_description/meshes/link_straight_gripper.STL" />
+          filename="package://stretch_tool_share/tool_share/stretch_dex_wrist/stretch_description/meshes/link_straight_gripper.STL" />
       </geometry>
       <material
         name="">
@@ -200,7 +200,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://stretch_description/meshes/link_straight_gripper.STL" />
+          filename="package://stretch_tool_share/tool_share/stretch_dex_wrist/stretch_description/meshes/link_straight_gripper.STL" />
       </geometry>
     </collision>
   </link>


### PR DESCRIPTION
This PR make `stretch_tool_share` to catkin package.
The reason why I made this PR is to find `stretch_tool_share` and `stretch_ros` from `tool_share/stretch_dex_wrist/stretch_description/urdf/stretch_description.xacro`

https://github.com/knorth55/stretch_tool_share/blob/02e6ad6b1789b83378247b80533906fc97a7106f/tool_share/stretch_dex_wrist/stretch_description/urdf/stretch_description.xacro#L4-L12